### PR TITLE
updating Elasticsearch.Net to 6.8.2

### DIFF
--- a/src/ElasticSearchTelemetryConsumer/ElasticSearchTelemetryConsumer.cs
+++ b/src/ElasticSearchTelemetryConsumer/ElasticSearchTelemetryConsumer.cs
@@ -65,8 +65,7 @@ namespace Orleans.Telemetry
 			{
 				var singleNode = new SingleNodeConnectionPool(esurl);
 
-				var cc = new ConnectionConfiguration(singleNode,
-						connectionSettings => new ElasticsearchJsonNetSerializer())
+				var cc = new ConnectionConfiguration(singleNode, new ElasticsearchJsonNetSerializer())
 					.EnableHttpPipelining()
 					.ThrowExceptions();
 
@@ -368,8 +367,8 @@ namespace Orleans.Telemetry
 			{
 				var ret = await GetClient(this._elasticSearchUri)
 					.BulkPutAsync<VoidResponse>(
-				        bbo.ToArray(), 
-				        br => br.Refresh(false));
+						PostData.MultiJson(bbo.ToArray()),
+						new BulkRequestParameters { Refresh = Refresh.False });
 			}
 			catch (Exception ex)
 			{

--- a/src/ElasticSearchTelemetryConsumer/Orleans.TelemetryConsumers.ElasticSearch.csproj
+++ b/src/ElasticSearchTelemetryConsumer/Orleans.TelemetryConsumers.ElasticSearch.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elasticsearch.Net" Version="2.5.8" />
+    <PackageReference Include="Elasticsearch.Net" Version="6.8.2" />
     <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="2.3.0" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
   </ItemGroup>

--- a/src/ElasticSearchTelemetryConsumer/Serializer/ElasticsearchJsonNetSerializer.cs
+++ b/src/ElasticSearchTelemetryConsumer/Serializer/ElasticsearchJsonNetSerializer.cs
@@ -14,84 +14,83 @@ namespace Orleans.TelemetryConsumers.ElasticSearch.Serializer
 {
 	public class ElasticsearchJsonNetSerializer : IElasticsearchSerializer
 	{
-		private static readonly Encoding ExpectedEncoding = new UTF8Encoding(false);
-		/// <summary>
-		/// The size of the buffer to use when writing the serialized request
-		/// to the request stream
-		/// Performance tests as part of https://github.com/elastic/elasticsearch-net/issues/1899 indicate this 
-		/// to be a good compromise buffer size for performance throughput and bytes allocated.
-		/// </summary>
-		protected virtual int BufferSize => 1024;
+        private static readonly Encoding ExpectedEncoding = new UTF8Encoding(false);
 
-		private readonly JsonSerializerSettings _settings;
-		private JsonSerializer _defaultSerializer;
+        /// <summary>
+        /// The size of the buffer to use when writing the serialized request
+        /// to the request stream
+        /// Performance tests as part of https://github.com/elastic/elasticsearch-net/issues/1899 indicate this
+        /// to be a good compromise buffer size for performance throughput and bytes allocated.
+        /// </summary>
+        protected virtual int BufferSize => 1024;
 
-		public ElasticsearchJsonNetSerializer(IList<JsonConverter> converters = null)
-		{
-			//_settings = settings ?? CreateSettings();
-			_settings = CreateSettings();
+        private readonly JsonSerializerSettings _settings;
+        private JsonSerializer _defaultSerializer;
 
-			if (converters != null)
-			{
-				if (_settings.Converters != null)
-				{
-					foreach (var converter in converters)
-					{
-						_settings.Converters.Add(converter);
-					}
-				}
-				else
-				{
-					_settings.Converters = converters;
-				}
-			}
+        public ElasticsearchJsonNetSerializer(JsonSerializerSettings settings = null)
+        {
+            _settings = settings ?? CreateSettings();
+            this._defaultSerializer = JsonSerializer.Create(_settings);
+        }
 
-			this._defaultSerializer = JsonSerializer.Create(_settings);
-		}
+        private JsonSerializerSettings CreateSettings()
+        {
+            var settings = new JsonSerializerSettings()
+            {
+                DefaultValueHandling = DefaultValueHandling.Include,
+                NullValueHandling = NullValueHandling.Ignore,
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+            };
+            return settings;
+        }
 
-		private JsonSerializerSettings CreateSettings()
-		{
-			var settings = new JsonSerializerSettings()
-			{
-				DefaultValueHandling = DefaultValueHandling.Include,
-				NullValueHandling = NullValueHandling.Ignore,
-			};
-			return settings;
-		}
+        public object Deserialize(Type type, Stream stream)
+        {
+            var settings = this._settings;
+            return _Deserialize(type, stream, settings);
+        }
 
+        public T Deserialize<T>(Stream stream)
+        {
+            var settings = this._settings;
+            return (T)_Deserialize(typeof(T), stream, settings);
+        }
 
-		public T Deserialize<T>(Stream stream)
-		{
-			var settings = this._settings;
-			return _Deserialize<T>(stream, settings);
-		}
+        public Task<object> DeserializeAsync(Type type, Stream stream, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Task.FromResult(_Deserialize(type, stream));
+        }
 
-		public async Task<T> DeserializeAsync<T>(Stream responseStream, CancellationToken cancellationToken = new CancellationToken())
-		{
-			return this.Deserialize<T>(responseStream);
-		}
+        protected internal object _Deserialize(Type type, Stream stream, JsonSerializerSettings settings = null)
+        {
+            settings = settings ?? this._settings;
+            var serializer = JsonSerializer.Create(settings);
+            var jsonTextReader = new JsonTextReader(new StreamReader(stream));
+            var t = serializer.Deserialize(jsonTextReader, type);
+            return t;
+        }
 
-		protected internal T _Deserialize<T>(Stream stream, JsonSerializerSettings settings = null)
-		{
-			settings = settings ?? this._settings;
-			var serializer = JsonSerializer.Create(settings);
-			var jsonTextReader = new JsonTextReader(new StreamReader(stream));
-			var t = (T)serializer.Deserialize(jsonTextReader, typeof(T));
-			return t;
-		}
+        public Task<T> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var result = this.Deserialize<T>(stream);
+            return Task.FromResult(result);
+        }
 
+        public void Serialize<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented)
+        {
+            using (var writer = new StreamWriter(stream, ExpectedEncoding, BufferSize, leaveOpen: true))
+            using (var jsonWriter = new JsonTextWriter(writer))
+            {
+                _defaultSerializer.Serialize(jsonWriter, data);
+                writer.Flush();
+                jsonWriter.Flush();
+            }
+        }
 
-		public void Serialize(object data, Stream writableStream, SerializationFormatting formatting = SerializationFormatting.Indented)
-		{
-			using (var writer = new StreamWriter(writableStream, ExpectedEncoding, BufferSize, leaveOpen: true))
-			using (var jsonWriter = new JsonTextWriter(writer))
-			{
-				_defaultSerializer.Serialize(jsonWriter, data);
-				writer.Flush();
-				jsonWriter.Flush();
-			}
-		}
-
-		public IPropertyMapping CreatePropertyMapping(MemberInfo memberInfo) => null;
-	}
+        public Task SerializeAsync<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Serialize(data, stream, formatting);
+            return Task.CompletedTask;
+        }
+    }
 }


### PR DESCRIPTION
This PR updates ElasticSearch.Net to version 6.8.2.

I brought in the same serializer changes made in https://github.com/amccool/AM.Extensions.Logging.ElasticSearch